### PR TITLE
overlayed histogram

### DIFF
--- a/apps/frontend/app/components/graphs/base/Histogram.tsx
+++ b/apps/frontend/app/components/graphs/base/Histogram.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import * as d3 from 'd3';
 import { html } from 'd3';
+import { getSeriesColor } from '../../../lib/graphColors';
 
 export interface HistogramBin {
   x0: number;
@@ -60,7 +61,7 @@ export const Histogram: React.FC<HistogramProps> = ({
             .map((s, index) => ({
               label: s.label || `Series ${index + 1}`,
               data: s.data,
-              color: s.color,
+              color: getSeriesColor(index, s.color, fillColor),
             }))
         : [{ label: title || 'Distribution', data, color: fillColor }],
     [series, title, data, fillColor],
@@ -150,7 +151,7 @@ export const Histogram: React.FC<HistogramProps> = ({
     const bars: RenderBar[] = binsBySeries.flatMap((seriesBins, seriesIndex) => {
       const seriesConfig = finalSeries[seriesIndex];
       const totalPoints = seriesConfig?.data.length ?? 0;
-      const color = seriesConfig?.color || fillColor;
+      const color = seriesConfig?.color ?? fillColor;
       const label = seriesConfig?.label || `Series ${seriesIndex + 1}`;
 
       return seriesBins.map((bin, binIndex) => {

--- a/apps/frontend/app/components/graphs/base/LinePlot.tsx
+++ b/apps/frontend/app/components/graphs/base/LinePlot.tsx
@@ -12,7 +12,7 @@ interface LinePlotProps {
   yDomain?: [number, number];
   height?: number;
   className?: string;
-  classForSeries?: (index: number) => string;
+  styleForSeries?: (index: number) => React.CSSProperties | undefined;
 }
 
 export const LinePlot: React.FC<LinePlotProps> = ({
@@ -21,7 +21,7 @@ export const LinePlot: React.FC<LinePlotProps> = ({
   yDomain = [0, 100],
   height = 400,
   className = "",
-  classForSeries,
+  styleForSeries,
 }) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const svgRef = useRef<SVGSVGElement>(null);
@@ -157,14 +157,32 @@ export const LinePlot: React.FC<LinePlotProps> = ({
       .data(data)
       .join("path")
       .attr("clip-path", `url(#${clipPathId})`)
-      .attr("class", (_, i) => `line-path ${classForSeries?.(i) ?? ""}`)
+      .attr("class", "line-path")
+      .style("stroke", (_, i) => styleForSeries?.(i)?.stroke?.toString() ?? null)
+      .style("opacity", (_, i) => {
+        const opacity = styleForSeries?.(i)?.opacity;
+        return typeof opacity === "number" ? opacity : null;
+      })
+      .style("stroke-width", (_, i) => {
+        const strokeWidth = styleForSeries?.(i)?.strokeWidth;
+        return strokeWidth !== undefined ? strokeWidth.toString() : null;
+      })
       .attr("d", lineGenerator);
 
     // Context lines
     context.selectAll<SVGPathElement, DataPoint[]>(".line-context")
       .data(data)
       .join("path")
-      .attr("class", (_, i) => `line-context ${classForSeries?.(i) ?? ""}`)
+      .attr("class", "line-context")
+      .style("stroke", (_, i) => styleForSeries?.(i)?.stroke?.toString() ?? null)
+      .style("opacity", (_, i) => {
+        const opacity = styleForSeries?.(i)?.opacity;
+        return typeof opacity === "number" ? opacity : null;
+      })
+      .style("stroke-width", (_, i) => {
+        const strokeWidth = styleForSeries?.(i)?.strokeWidth;
+        return strokeWidth !== undefined ? strokeWidth.toString() : null;
+      })
       .attr("d", lineGenerator2);
 
     // Brush
@@ -180,7 +198,7 @@ export const LinePlot: React.FC<LinePlotProps> = ({
       .selectAll(".selection")
       .attr("class", "selection fill-muted-foreground/30 stroke-border");
 
-  }, [data, width, height, xDomain, yDomain, classForSeries, clipPathId]);
+  }, [data, width, height, xDomain, yDomain, styleForSeries, clipPathId]);
 
   return (
     <div ref={containerRef} className={`w-full bg-card rounded-lg ${className}`}>

--- a/apps/frontend/app/components/graphs/domain/DisplacementPlot.tsx
+++ b/apps/frontend/app/components/graphs/domain/DisplacementPlot.tsx
@@ -6,10 +6,11 @@ import {
   RawSuspensionData,
   NormalizedPoint,
 } from "../../../lib/telemetryUtils";
+import { getSeriesColor } from "../../../lib/graphColors";
 
 export interface SeriesConfig {
   label: string;
-  color: string;
+  color?: string;
   rawData: RawSuspensionData[];
   freq: number;
   min?: number;
@@ -76,7 +77,7 @@ export const DisplacementPlot: React.FC<DisplacementPlotProps> = ({
         <div className="flex gap-4 text-xs">
           {series.map((s, index) => (
             <div key={`${s.label}-${index}`} className="flex items-center gap-2">
-              <div className="w-3 h-3 rounded-full" style={{ background: s.color }}></div>
+              <div className="w-3 h-3 rounded-full" style={{ background: getSeriesColor(index, s.color) }}></div>
               <span className="font-medium text-gray-600">
                 {s.label}
                 {s.dynamicSag ? " (sag)" : ""}
@@ -91,18 +92,18 @@ export const DisplacementPlot: React.FC<DisplacementPlotProps> = ({
           data={chartData}
           yDomain={[0, 100]}
           height={height}
-          classForSeries={(i) => {
+          styleForSeries={(i) => {
             const meta = lineMetadata[i];
-            // Fallback style for unexpected metadata mismatches.
             if (!meta) {
-              return i % 2 === 0 ? "line-primary" : "line-secondary";
+              return {
+                stroke: getSeriesColor(i),
+              };
             }
 
-            if (meta.isSag) {
-              return "line-lowemphasis";
-            }
-
-            return meta.seriesIndex % 2 === 0 ? "line-primary" : "line-secondary";
+            return {
+              stroke: getSeriesColor(meta.seriesIndex, series[meta.seriesIndex]?.color),
+              opacity: meta.isSag ? 0.35 : 1,
+            };
           }}
         />
       </div>

--- a/apps/frontend/app/components/graphs/domain/TravelHistogram.tsx
+++ b/apps/frontend/app/components/graphs/domain/TravelHistogram.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo } from "react";
 import { Histogram, HistogramSeries } from "../base/Histogram";
 import { RawSuspensionData, processHistogramData } from "../../../lib/telemetryUtils";
+import { getSeriesColor } from "../../../lib/graphColors";
 
 interface TravelHistogramProps {
   rawData?: RawSuspensionData[];
@@ -33,7 +34,7 @@ export const TravelHistogram: React.FC<TravelHistogramProps> = ({
     if (series && series.length > 0) {
       return series.map((seriesItem, index) => ({
         label: seriesItem.label,
-        color: seriesItem.fillColor || (index === 0 ? fillColor : undefined),
+        color: getSeriesColor(index, seriesItem.fillColor, fillColor),
         data: processHistogramData(seriesItem.rawData, seriesItem.min, seriesItem.max),
       }));
     }
@@ -60,6 +61,7 @@ export const TravelHistogram: React.FC<TravelHistogramProps> = ({
         xDomain={[0, 100]}
         height={height}
         title={title}
+        fillColor={fillColor}
       />
     </div>
   );

--- a/apps/frontend/app/components/runs/chart-sections.tsx
+++ b/apps/frontend/app/components/runs/chart-sections.tsx
@@ -6,6 +6,7 @@ import {
 import { TravelHistogram } from "app/components/graphs/domain/TravelHistogram";
 import { SectionHeader } from "app/components/ui/run-elements";
 import { Profile, Run } from "@repo/database";
+import { getSeriesColor } from "app/lib/graphColors";
 
 interface ChartSectionProps {
   selected: Run[];
@@ -29,12 +30,6 @@ function getProfileFromRun(run: Run): Profile | null {
   }
 
   return profileCandidate as Profile;
-}
-
-// Chart color mapping by index
-function getSeriesColor(runIndex: number): string {
-  const colors = ["hsl(var(--chart-1))", "hsl(var(--chart-2))"];
-  return colors[runIndex % colors.length]!;
 }
 
 function getSeriesConfig(

--- a/apps/frontend/app/lib/graphColors.ts
+++ b/apps/frontend/app/lib/graphColors.ts
@@ -1,0 +1,19 @@
+const DEFAULT_SERIES_COLORS = ["hsl(var(--chart-1))", "hsl(var(--chart-2))"];
+
+export function getSeriesColor(
+  index: number,
+  explicitColor?: string,
+  fallbackColor?: string,
+): string {
+  if (typeof explicitColor === "string" && explicitColor.trim().length > 0) {
+    return explicitColor;
+  }
+
+  const normalizedIndex = Number.isFinite(index) ? Math.abs(Math.trunc(index)) : 0;
+  const paletteColor = DEFAULT_SERIES_COLORS[normalizedIndex % DEFAULT_SERIES_COLORS.length];
+  if (paletteColor) {
+    return paletteColor;
+  }
+
+  return fallbackColor ?? "hsl(var(--chart-1))";
+}


### PR DESCRIPTION
- muti series rendering
- render bars overlaid in same bin
- percentage normalisation (for fair comparison)
- smaller values render on top (with opacity)
- Display all series percentages in tooltip
- colour coded legend with series indicators
- legend hover filtering
- prevent x-axis line overlap (UI bug fix)
- comparison histograms display side-by-side
- Scale single run histogram to half width