### PR TITLE
compression rebound speed histogram

### DIFF
--- a/apps/frontend/app/components/graphs/base/LineHistogram.tsx
+++ b/apps/frontend/app/components/graphs/base/LineHistogram.tsx
@@ -1,31 +1,31 @@
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react'
 import * as d3 from 'd3';
 import { getSeriesColor } from '../../../lib/graphColors';
 
-export interface HistogramBin {
-  x0: number;
-  x1: number;
-  percent: number;
+export interface LineHistogramBin {
+    x0: number;
+    x1: number; 
+    percent: number;
 }
 
-export interface HistogramSeries {
+export interface LineHistogramSeries {
   label: string;
   data: number[];
   color?: string;
 }
 
-export interface HistogramProps {
+export interface LineHistogramProps {
   data?: number[];
-  series?: HistogramSeries[];
+  series?: LineHistogramSeries[];
   height?: number;
   xDomain?: [number, number];
   className?: string;
   fillColor?: string;
   title?: string;
-  binCount?: number;
+  binCount?: number; 
 }
 
-export const Histogram: React.FC<HistogramProps> = ({ 
+export const LineHistogram: React.FC<LineHistogramProps> = ({
   data = [],
   series,
   height = 500, 
@@ -52,8 +52,8 @@ export const Histogram: React.FC<HistogramProps> = ({
   }, []);
 
   // Main D3 rendering
-  const finalSeries: HistogramSeries[] = useMemo(() =>
-      // If series prop provided map each series item
+  const finalSeries: LineHistogramSeries[] = useMemo(() =>
+    // If series prop provided map each series item
       series && series.length > 0
         ? series
             .filter((s) => Array.isArray(s.data))
@@ -83,24 +83,28 @@ export const Histogram: React.FC<HistogramProps> = ({
     const innerHeight = height - margin.top - margin.bottom;
     if (innerWidth <= 0 || innerHeight <= 0) return;
 
-    // Bin source data into histogram buckets
-    const finalDomain: [number, number] = xDomain ?? [0, 100];
+    // Bin each series
+    const finalDomain: [number, number] = xDomain ?? [0, 100]; // our x domain is -4000 to 4000 
     const binGenerator = d3
       .bin<number, number>()
       .domain(finalDomain)
       .thresholds(binCount);
     const binsBySeries = finalSeries.map((s) => binGenerator(s.data));
 
-    const firstSeriesBins = binsBySeries[0];
-    if (!firstSeriesBins) return;
-    const firstBin = firstSeriesBins[0];
-    const lastBin = firstSeriesBins[firstSeriesBins.length - 1];
-    if (!firstBin || !lastBin || firstBin.x0 == null || lastBin.x1 == null) return;
+    // Build line points for each series
+    const linePointsBySeries = binsBySeries.map((seriesBins, seriesIndex) => {
+      const totalPoints = finalSeries[seriesIndex]?.data.length ?? 0;
+      return seriesBins.map((bin) => ({
+        x: ((bin.x0 ?? 0) + (bin.x1 ?? 0)) / 2,
+        y: totalPoints > 0 ? (bin.length / totalPoints) * 100 : 0, 
+      }));
+    }
+    );
 
     // Scales
     const x = d3
       .scaleLinear()
-      .domain([firstBin.x0, lastBin.x1])
+      .domain(finalDomain)
       .range([0, innerWidth]);
 
     const maxPercent =
@@ -136,113 +140,21 @@ export const Histogram: React.FC<HistogramProps> = ({
     const tooltip = d3.select(tooltipRef.current);
     tooltip.style("opacity", 0);
 
-    type RenderBar = {
+    type RenderSeries = {                                                                                                                                                                    
       seriesIndex: number;
-      binIndex: number;
-      x0: number;
-      x1: number;
-      count: number;
-      percent: number;
-      total: number;
-      color: string;
+      color: string;                                                                                                                                                                         
       label: string;
+      points: { x: number; y: number }[];
     };
 
-    // Prepare data for rendering
-    const seriesCount = Math.max(1, finalSeries.length);
-    const bars: RenderBar[] = binsBySeries.flatMap((seriesBins, seriesIndex) => {
-      const seriesConfig = finalSeries[seriesIndex];
-      const totalPoints = seriesConfig?.data.length ?? 0;
-      const color = seriesConfig?.color ?? fillColor;
-      const label = seriesConfig?.label || `Series ${seriesIndex + 1}`;
+    const renderSeries: RenderSeries[] = linePointsBySeries.map((points, seriesIndex) => ({                                                                                                  
+      seriesIndex,                                                                                                                                                                           
+      color: finalSeries[seriesIndex]?.color ?? fillColor,
+      label: finalSeries[seriesIndex]?.label ?? `Series ${seriesIndex + 1}`,                                                                                                                 
+      points,                                                                                                                                                                                
+    }));
 
-      return seriesBins.map((bin, binIndex) => {
-        const x0 = bin.x0 ?? 0;
-        const x1 = bin.x1 ?? x0;
-        const percent = totalPoints > 0 ? (bin.length / totalPoints) * 100 : 0;
-
-        return {
-          seriesIndex,
-          binIndex,
-          x0,
-          x1,
-          count: bin.length,
-          percent,
-          total: totalPoints,
-          color,
-          label,
-        };
-      });
-    }).sort((a, b) => {
-      // Group by bin, then sort smaller percentages last (rendered on top)
-      if (a.binIndex !== b.binIndex) return a.binIndex - b.binIndex;
-      return b.percent - a.percent;
-    });
-
-    const barsByBin = d3.group(bars, (bar) => bar.binIndex);
-    const minPercentByBin = d3.rollup(
-      bars,
-      (v) => d3.min(v, (b) => b.percent) ?? 0,
-      (bar) => bar.binIndex
-    );
-
-    // Draw overlaid bars (all in same bin) + interactive tooltip
-    g.selectAll<SVGRectElement, RenderBar>("rect")
-      .data(bars, (bar) => `${bar.seriesIndex}-${bar.binIndex}`)
-      .join("rect")
-      .attr("x", (bar) => x(bar.x0) + 1)
-      .attr("width", (bar) => Math.max(0, x(bar.x1) - x(bar.x0) - 1))
-      .attr("y", (bar) => y(bar.percent))
-      .attr("height", (bar) => y(0) - y(bar.percent))
-      .attr("rx", 2)
-      .attr("ry", 2)
-      .attr("fill", (bar) => bar.color)
-      .attr("stroke", "hsl(var(--card))")
-      .attr("stroke-width", 0.5)
-      .attr("opacity", (bar) => {
-        // If hovering over legend, dim non-hovered series
-        if (hoveredSeriesIndex !== null && bar.seriesIndex !== hoveredSeriesIndex) {
-          return 0.1;
-        }
-
-        // Apply opacity to the smallest bar in each bin on multi series charts
-        const binBars = barsByBin.get(bar.binIndex) ?? [];
-        if (binBars.length <= 1) return 1;
-        const minPercent = minPercentByBin.get(bar.binIndex) ?? 0;
-        return bar.percent === minPercent ? 0.5 : 1;
-      })
-      .attr("class", "cursor-pointer")
-      .on("mouseenter", function (event: MouseEvent, bar) {
-        d3.select(this).style("filter", "brightness(1.1)");
-
-        const barsInBin = barsByBin.get(bar.binIndex) ?? [];
-        const range = `${bar.x0.toFixed(1)} - ${bar.x1.toFixed(1)}`;
-        const tooltipLines = barsInBin
-          .map((b) => `<div class="text-xs text-gray-600">${b.label}: ${b.percent.toFixed(1)}%</div>`)
-          .join("");
-        
-        tooltip.style("opacity", 1);
-        tooltip.selectAll("*").remove();
-        tooltip.append("div").attr("class", "text-xs text-gray-500").text(`Range: ${range}`);
-        barsInBin.forEach((b) => {
-          tooltip.append("div")
-            .attr("class", "text-xs text-gray-600")
-            .text(`${b.label}: ${b.percent.toFixed(1)}%`);
-        });
-
-        const [xPos, yPos] = d3.pointer(event, containerRef.current);
-        tooltip.style("left", `${xPos}px`).style("top", `${yPos - 10}px`);
-      })
-      .on("mousemove", (event: MouseEvent) => {
-        const [xPos, yPos] = d3.pointer(event, containerRef.current);
-        tooltip.style("left", `${xPos}px`).style("top", `${yPos - 10}px`);
-      })
-      .on("mouseleave", function () {
-        d3.select(this).style("filter", null);
-        tooltip.style("opacity", 0);
-      });
-
-    // Draw axes
+    // Draw axis
     g.selectAll<SVGGElement, null>("g.x-axis")
       .data([null])
       .join("g")
@@ -254,15 +166,43 @@ export const Histogram: React.FC<HistogramProps> = ({
 
     const yTickFormat = d3.format(".0f");
     g.selectAll<SVGGElement, null>("g.y-axis")
-      .data([null])
-      .join("g")
+      .data([null])                                                                                                                                                                          
+      .join("g")    
       .attr("class", "y-axis")
       .call(d3.axisLeft(y).ticks(5).tickFormat((value) => `${yTickFormat(Number(value))}%`))
       .call((axisGroup) => axisGroup.selectAll(".domain, .tick line").attr("class", "stroke-border"))
       .call((axisGroup) => axisGroup.selectAll(".tick text").attr("class", "text-muted-foreground text-xs"));
 
-  }, [finalSeries, width, height, fillColor, xDomain, binCount, hoveredSeriesIndex]); 
+    g.selectAll("line.zero-line")
+      .data([null])
+      .join("line")
+      .attr("class", "zero-line")                                                                                                                                                            
+      .attr("x1", x(0)).attr("x2", x(0))
+      .attr("y1", 0).attr("y2", innerHeight)                                                                                                                                                 
+      .attr("stroke", "hsl(var(--border))")                                                                                                                                                  
+      .attr("stroke-dasharray", "4,4");
 
+    // Draw lines
+    const lineGenerator = d3.line<{ x: number; y: number }>()                                                                                                                                
+      .x((point) => x(point.x))                                                                                                                                
+      .y((point) => y(point.y))                                                                                                                                   
+      .curve(d3.curveMonotoneX);
+
+    g.selectAll<SVGPathElement, RenderSeries>("path.series-line") 
+      .data(renderSeries, (s) => s.seriesIndex)                                                                                                                                                
+      .join("path") 
+      .attr("d", (s) => lineGenerator(s.points))
+      .attr("fill", "none")
+      .attr("stroke", (s) => s.color)
+      .attr("stroke-width", 2)
+      .attr("opacity", (d) => (hoveredSeriesIndex === null || hoveredSeriesIndex === d.seriesIndex ? 1 : 0.3));
+
+    // Tooltip setup
+    // (no tooltip as of yet)
+    
+  } , [finalSeries, width, height, xDomain, binCount, hoveredSeriesIndex]);
+
+  // JSX return
   return (
     <div className={`bg-white p-6 rounded-xl shadow-sm border border-gray-200 relative w-full ${className}`} ref={containerRef}>
       <div className="flex items-center justify-between mb-4">

--- a/apps/frontend/app/components/graphs/base/LineHistogram.tsx
+++ b/apps/frontend/app/components/graphs/base/LineHistogram.tsx
@@ -84,7 +84,7 @@ export const LineHistogram: React.FC<LineHistogramProps> = ({
     if (innerWidth <= 0 || innerHeight <= 0) return;
 
     // Bin each series
-    const finalDomain: [number, number] = xDomain ?? [0, 100]; // our x domain is -4000 to 4000 
+    const finalDomain: [number, number] = xDomain ?? [0, 100];
     const binGenerator = d3
       .bin<number, number>()
       .domain(finalDomain)

--- a/apps/frontend/app/components/graphs/base/LineHistogram.tsx
+++ b/apps/frontend/app/components/graphs/base/LineHistogram.tsx
@@ -200,7 +200,7 @@ export const LineHistogram: React.FC<LineHistogramProps> = ({
     // Tooltip setup
     // (no tooltip as of yet)
     
-  } , [finalSeries, width, height, xDomain, binCount, hoveredSeriesIndex]);
+  } , [finalSeries, width, height, xDomain, binCount]); // add hoveredSeriesIndex back for tooltip
 
   // JSX return
   return (

--- a/apps/frontend/app/components/graphs/domain/VelocityHistogram.tsx
+++ b/apps/frontend/app/components/graphs/domain/VelocityHistogram.tsx
@@ -36,7 +36,7 @@ export const VelocityHistogram: React.FC<VelocityHistogramProps> = ({
   max,
 }) => {
     // buildVelocitySamples on rawData to get velocity samples
-    const histogramSeries = useMemo<HistogramSeries[]>(() => {
+    const histogramSeries = useMemo<LineHistogramSeries[]>(() => {
         if (series && series.length > 0) {
             return series.map((seriesItem, index) => ({
                 label: seriesItem.label,

--- a/apps/frontend/app/components/graphs/domain/VelocityHistogram.tsx
+++ b/apps/frontend/app/components/graphs/domain/VelocityHistogram.tsx
@@ -1,0 +1,73 @@
+import React, { useMemo } from "react";
+import { SeriesConfig } from "./DisplacementPlot"; 
+import { 
+    LineHistogram, 
+    LineHistogramSeries } from "../base/LineHistogram";
+import {
+    buildVelocitySamples, 
+    RawSuspensionData} from '../../../lib/telemetryUtils';
+import { getSeriesColor } from "app/lib/graphColors";
+
+interface VelocityHistogramProps {
+  rawData?: RawSuspensionData[];
+  series?: {
+    label: string;
+    rawData: RawSuspensionData[];
+    freq: number;
+    fillColor?: string;
+    min?: number;
+    max?: number;
+  }[];
+  title?: string;
+  fillColor?: string;
+  height?: number;
+  min?: number;
+  max?: number;
+}
+
+// Renders a histogram of velocity values
+export const VelocityHistogram: React.FC<VelocityHistogramProps> = ({
+  rawData = [],
+  series,
+  title = "Suspension Velocity",
+  fillColor = "hsl(var(--chart-1))",
+  height = 200,
+  min,
+  max,
+}) => {
+    // buildVelocitySamples on rawData to get velocity samples
+    const histogramSeries = useMemo<HistogramSeries[]>(() => {
+        if (series && series.length > 0) {
+            return series.map((seriesItem, index) => ({
+                label: seriesItem.label,
+                color: getSeriesColor(index, seriesItem.fillColor, fillColor),
+                data: buildVelocitySamples(seriesItem.rawData, seriesItem.freq, seriesItem.min, seriesItem.max).map(s => s.velocity),
+            }));
+        }
+        
+        return [
+            {
+                label: title,
+                color: fillColor,
+                data: buildVelocitySamples(rawData, 100, min, max).map(s => s.velocity),
+            },
+        ];
+    }, [series, rawData, min, max, fillColor, title]);
+
+    // Keep layout stable
+    if (!histogramSeries.some((seriesItem) => seriesItem.data.length > 0)) {
+        return <div className="h-40 flex items-center justify-center text-gray-500 text-sm">No data</div>;
+    }
+
+    return (
+    <div className="w-full">
+        <LineHistogram
+        series={histogramSeries}
+        xDomain={[-4000,4000]} 
+        height={height}
+        title={title}
+        binCount={50}
+        />
+    </div>
+    );
+};

--- a/apps/frontend/app/components/graphs/domain/VelocityHistogram.tsx
+++ b/apps/frontend/app/components/graphs/domain/VelocityHistogram.tsx
@@ -1,5 +1,4 @@
 import React, { useMemo } from "react";
-import { SeriesConfig } from "./DisplacementPlot"; 
 import { 
     LineHistogram, 
     LineHistogramSeries } from "../base/LineHistogram";
@@ -10,6 +9,7 @@ import { getSeriesColor } from "app/lib/graphColors";
 
 interface VelocityHistogramProps {
   rawData?: RawSuspensionData[];
+  freq?: number;
   series?: {
     label: string;
     rawData: RawSuspensionData[];
@@ -28,6 +28,7 @@ interface VelocityHistogramProps {
 // Renders a histogram of velocity values
 export const VelocityHistogram: React.FC<VelocityHistogramProps> = ({
   rawData = [],
+  freq = 100,
   series,
   title = "Suspension Velocity",
   fillColor = "hsl(var(--chart-1))",
@@ -49,10 +50,10 @@ export const VelocityHistogram: React.FC<VelocityHistogramProps> = ({
             {
                 label: title,
                 color: fillColor,
-                data: buildVelocitySamples(rawData, 100, min, max).map(s => s.velocity),
+                data: buildVelocitySamples(rawData, freq, min, max).map(s => s.velocity),
             },
         ];
-    }, [series, rawData, min, max, fillColor, title]);
+    }, [series, rawData, freq, min, max, fillColor, title]);
 
     // Keep layout stable
     if (!histogramSeries.some((seriesItem) => seriesItem.data.length > 0)) {

--- a/apps/frontend/app/components/runs/chart-sections.tsx
+++ b/apps/frontend/app/components/runs/chart-sections.tsx
@@ -120,7 +120,7 @@ export function DisplacementSection({
             highlight={highlight}
           />
           <DisplacementPlot
-            title="Rear Shock Travel"
+            title="Rear Suspension Travel"
             series={selected.map((run, i) =>
               getSeriesConfig(run, i, jsonData, "rear", undefined, true),
             )}

--- a/apps/frontend/app/components/runs/chart-sections.tsx
+++ b/apps/frontend/app/components/runs/chart-sections.tsx
@@ -5,6 +5,7 @@ import {
   LineHighlight,
 } from "app/components/graphs/domain/DisplacementPlot";
 import { TravelHistogram } from "app/components/graphs/domain/TravelHistogram";
+import { VelocityHistogram } from "app/components/graphs/domain/VelocityHistogram";
 import { ReboundCompressionPlot } from "app/components/graphs/domain/ReboundCompressionPlot";
 import { SectionHeader } from "app/components/ui/run-elements";
 import { Run } from "@repo/database";
@@ -90,7 +91,7 @@ function getSeriesConfig(
   };
 }
 
-// ---------------------- Displacement Plot ----------------------
+// ---------------------- Line Plots ----------------------
 export function DisplacementSection({
   selected,
   jsonData,
@@ -107,19 +108,19 @@ export function DisplacementSection({
 
   return (
     <section>
-      <SectionHeader>Displacement & Velocity</SectionHeader>
+      <SectionHeader>Line Plots</SectionHeader>
 
       {isCompareMode ? (
         <div className="grid grid-cols-1 gap-6 w-full">
           <DisplacementPlot
-            title="Front Fork Comparison"
+            title="Front Suspension Travel"
             series={selected.map((run, i) =>
               getSeriesConfig(run, i, jsonData, "front", undefined, true),
             )}
             highlight={highlight}
           />
           <DisplacementPlot
-            title="Rear Shock Comparison"
+            title="Rear Shock Travel"
             series={selected.map((run, i) =>
               getSeriesConfig(run, i, jsonData, "rear", undefined, true),
             )}
@@ -127,7 +128,7 @@ export function DisplacementSection({
           />
 
           <ReboundCompressionPlot
-            title="Front Suspension"
+            title="Front Suspension Speed"
             series={selected.map((run, i) =>
               getSeriesConfig(run, i, jsonData, "front", undefined, true),
             )}
@@ -138,7 +139,7 @@ export function DisplacementSection({
           />
 
           <ReboundCompressionPlot
-            title="Rear Suspension"
+            title="Rear Suspension Speed"
             series={selected.map((run, i) =>
               getSeriesConfig(run, i, jsonData, "rear", undefined, true),
             )}
@@ -153,30 +154,30 @@ export function DisplacementSection({
         !firstData.error && (
           <div className="grid grid-cols-1 gap-6">
             <DisplacementPlot
-              title="Suspension Displacement"
+              title="Suspension Travel"
               series={[
                 getSeriesConfig(
                   first,
                   0,
                   jsonData,
                   "front",
-                  "Front Fork",
+                  "Front Suspension",
                   true,
                 ),
-                getSeriesConfig(first, 1, jsonData, "rear", "Rear Shock", true),
+                getSeriesConfig(first, 1, jsonData, "rear", "Rear Suspension", true),
               ]}
               highlight={highlight}
             />
 
             <ReboundCompressionPlot
-              title="Front Suspension"
+              title="Front Suspension Speed"
               series={[
                 getSeriesConfig(
                   first,
                   0,
                   jsonData,
                   "front",
-                  "Front Fork",
+                  "Front Suspension",
                 ),
               ]}
               speedRegion={{ low: 50, high: 150 }}
@@ -186,14 +187,14 @@ export function DisplacementSection({
             />
 
             <ReboundCompressionPlot
-              title="Rear Suspension"
+              title="Rear Suspension Speed"
               series={[
                 getSeriesConfig(
                   first,
                   1,
                   jsonData,
                   "rear",
-                  "Rear Shock",
+                  "Rear Suspension",
                 ),
               ]}
               speedRegion={{ low: 50, high: 150 }}
@@ -208,7 +209,7 @@ export function DisplacementSection({
   );
 }
 
-// ---------------------- Histogram Plot ----------------------
+// ---------------------- Histogram Plots ----------------------
 export function HistogramSection({
   selected,
   jsonData,
@@ -259,7 +260,7 @@ export function HistogramSection({
     if (!data || data.error) {
       return (
         <section>
-          <SectionHeader>Travel Histogram</SectionHeader>
+          <SectionHeader>Histogram Plots</SectionHeader>
           <div className="p-4 text-gray-400 italic">
             No histogram data available
           </div>
@@ -269,25 +270,32 @@ export function HistogramSection({
 
     return (
       <section>
-        <SectionHeader>Travel Histogram</SectionHeader>
-        <div className="w-full md:w-1/2">
+        <SectionHeader>Histogram Plots</SectionHeader>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6 w-full">
           <TravelHistogram
             title="Suspension Travel"
             series={[
               {
-                label: "Front Fork",
+                label: "Front Suspension",
                 rawData: frontSeries[0]?.rawData ?? [],
                 fillColor: getSeriesColor(0),
                 min: frontSeries[0]?.min,
                 max: frontSeries[0]?.max,
               },
               {
-                label: "Rear Shock",
+                label: "Rear Suspension",
                 rawData: rearSeries[0]?.rawData ?? [],
                 fillColor: getSeriesColor(1),
                 min: rearSeries[0]?.min,
                 max: rearSeries[0]?.max,
               },
+            ]}
+          />
+          <VelocityHistogram
+            title="Suspension Speed"
+            series={[
+              getSeriesConfig(singleRun, 0, jsonData, "front", "Front Suspension"),
+              getSeriesConfig(singleRun, 1, jsonData, "rear", "Rear Suspension"),
             ]}
           />
         </div>
@@ -297,16 +305,30 @@ export function HistogramSection({
 
   return (
     <section>
-      <SectionHeader>Travel Histogram</SectionHeader>
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-6 w-full">
+      <SectionHeader>Histogram Plots</SectionHeader>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-6 w-full mb-6">
         <TravelHistogram
-          title="Front Fork Comparison"
+          title="Front Suspension Travel"
           series={frontSeries}
         />
         <TravelHistogram
-          title="Rear Shock Comparison"
+          title="Rear Suspension Travel"
           series={rearSeries}
         />
+        
+        <VelocityHistogram
+          title="Front Suspension Speed"
+          series={selected.map((run, i) =>
+            getSeriesConfig(run, i, jsonData, "front"),
+          )}
+        />
+        <VelocityHistogram
+            title="Rear Suspension Speed"
+            series={selected.map((run, i) =>
+              getSeriesConfig(run, i, jsonData, "rear"),
+            )}
+        />
+
       </div>
     </section>
   );


### PR DESCRIPTION
Made `lineHistogram` base component (Very similar to `histogram` but it draws a line through the midpoints of the bin counts)
Made `velocityHistogram` (Uses `buildVelocitySamples` util to populate `lineHistogram` component) 
Cleaned up chart sections for consistency (Language: `Displacement` $\rightarrow$ `Travel`, `Fork/Shock` $\rightarrow$ `Suspension`)